### PR TITLE
108 Redirect to login form placeholder + redirect home on submit

### DIFF
--- a/frontend/src/components/Header/index.js
+++ b/frontend/src/components/Header/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { ReactComponent as LogoSvg } from "../../assets/stamacasa.svg";
-import { NavLink } from "react-router-dom";
+import { NavLink, useHistory } from "react-router-dom";
 import {
   Header as TFHeader,
   DevelopedBy
@@ -13,11 +13,14 @@ import { connect } from "react-redux";
 import "./header.scss";
 
 const Header = ({ user, loadUser }) => {
+  const history = useHistory();
+
   if (!user) {
     loadUser();
   }
+
   const handleLogin = () => {
-    UserThunks.authenticate();
+    history.push("/login");
   };
 
   const handleLogout = () => {

--- a/frontend/src/components/Login/index.js
+++ b/frontend/src/components/Login/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { LoginForm } from "@code4ro/taskforce-fe-components";
 import StamAcasaLogo from "../../images/stamacasa.svg";
 import "./login.scss";
@@ -13,6 +13,14 @@ const Login = () => {
   };
 
   const [loginData, setState] = useState(initialState);
+  const history = useHistory();
+
+  const handleLogin = () => {
+    setState(initialState); // Fix eslint unused warning
+
+    history.push("/");
+  };
+
   return (
     <div className="login">
       <img src={StamAcasaLogo} style={{ width: 300 }} alt={"logo"}></img>
@@ -20,7 +28,7 @@ const Login = () => {
         <LoginForm
           rightContent={<Link to="/register">Ai uitat parola?</Link>}
           initialState={loginData}
-          onSubmit={setState}
+          onSubmit={handleLogin}
         />
       </div>
     </div>


### PR DESCRIPTION
## What does it fix?

Closes #108 

Redirect to `/login` route instead of calling `UserThunks` `authenticate` mehtod.
Redirect back to `/` root when clicking submit (a dummy `setState` was left in there to avoid making too many changes).

### How has it been tested?
Manual dev test.