### PR TITLE
Add eslint rules for functional components and no console

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -10,5 +10,9 @@
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:prettier/recommended"
-  ]
+  ],
+  "rules": {
+    "no-console": ["error", { "allow": ["info", "error"] }],
+    "react/prefer-stateless-function": "error"
+  }
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,7 @@
 # editors
 .vscode
 .atom
+.idea
 
 # misc
 .DS_Store

--- a/frontend/src/serviceWorker.js
+++ b/frontend/src/serviceWorker.js
@@ -41,7 +41,7 @@ export function register(config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          console.info(
             "This web app is being served cache-first by a service " +
               "worker. To learn more, visit https://bit.ly/CRA-PWA"
           );
@@ -69,7 +69,7 @@ function registerValidSW(swUrl, config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              console.info(
                 "New content is available and will be used when all " +
                   "tabs for this page are closed. See https://bit.ly/CRA-PWA."
               );
@@ -82,7 +82,7 @@ function registerValidSW(swUrl, config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log("Content is cached for offline use.");
+              console.info("Content is cached for offline use.");
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -122,7 +122,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      console.log(
+      console.info(
         "No internet connection found. App is running in offline mode."
       );
     });


### PR DESCRIPTION
### What does it fix?

Added eslint rules to enforce functional components and allow only console.info and console.error