### PR TITLE
Update docker compose files to expose RabbitMQ port

### DIFF
--- a/backend/src/docker-compose-services.yml
+++ b/backend/src/docker-compose-services.yml
@@ -47,3 +47,8 @@ services:
     build:
         context: .
         dockerfile: StamAcasa.EmailService/Dockerfile
+    environment:
+        RABBITMQ__USER: admin
+        RABBITMQ__PASSWORD: Corona2020
+        RABBITMQ__HOSTNAME: rabbitmq
+        RABBITMQ__PORT: 5672

--- a/backend/src/docker-compose.yml
+++ b/backend/src/docker-compose.yml
@@ -81,5 +81,6 @@ services:
         RABBITMQ__USER: admin
         RABBITMQ__PASSWORD: Corona2020
         RABBITMQ__HOSTNAME: rabbitmq
+        RABBITMQ__PORT: 5672 
     depends_on:
       - rabbitmq


### PR DESCRIPTION
### Requirements for making a pull request

Thank you for contributing to our project! 

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.

### What does it fix?

Fixes issues with Email Service not able to connect to RabbitMQ.
The RabbitMQ port was not injected in the environment by the docker-compose file.

### How has it been tested?

Tested locally using:
`docker-compose -f docker-compose-dep.yml up --build`
`docker-compose -f docker-compose-services.yml up --build`
