### PR TITLE
Add caching for email templates

### DIFF
--- a/backend/src/StamAcasa.EmailService/EmailBuilder/EmailBuilderService.cs
+++ b/backend/src/StamAcasa.EmailService/EmailBuilder/EmailBuilderService.cs
@@ -1,6 +1,7 @@
 ﻿
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using StamAcasa.Common.Models;
 using StamAcasa.Common.Services.Emailing;
@@ -11,33 +12,46 @@ namespace StamAcasa.EmailService.EmailBuilder
     {
         private readonly ILogger<IEmailBuilderService> _logger;
         private readonly ITemplateFileSelector _templateFileSelector;
+        private readonly IMemoryCache _memoryCache;
 
-        public EmailBuilderService(ILogger<IEmailBuilderService> logger, ITemplateFileSelector templateFileSelector)
+        public EmailBuilderService(ILogger<IEmailBuilderService> logger, ITemplateFileSelector templateFileSelector, IMemoryCache memoryCache)
         {
             _logger = logger;
             _templateFileSelector = templateFileSelector;
+            _memoryCache = memoryCache;
         }
         public async Task<Email> BuildEmail(EmailRequestModel emailRequest)
         {
             _logger.LogInformation("Build email");
 
-            //TODO Cache templates to prevent storage read bottlenecks
-            var filePath = _templateFileSelector.GetTemplatePath(emailRequest.TemplateType);
-            using (var streamReader = File.OpenText(filePath))
+            var template = await GetTemplate(emailRequest.TemplateType);
+            template = FormatTemplate(template, emailRequest);
+            var emailModel = new Email
             {
-                string template = await streamReader.ReadToEndAsync();
-                template = FormatTemplate(template, emailRequest);
-                var emailModel = new Email
-                {
-                    FromName = "Admin Stam Acasa",
-                    FromEmail = "admin@stamacasa.ro",
-                    To = emailRequest.Address,
-                    Subject = "New Email",
-                    Content = template
-                };
+                FromName = "Admin Stam Acasa",
+                FromEmail = "admin@stamacasa.ro",
+                To = emailRequest.Address,
+                Subject = "New Email",
+                Content = template
+            };
 
-                return emailModel;
+            return emailModel;
+        }
+
+        private async Task<string> GetTemplate(EmailTemplate templateType)
+        {
+            if (!_memoryCache.TryGetValue<string>(templateType, out string template))
+            {
+                var filePath = _templateFileSelector.GetTemplatePath(templateType);
+                using (var streamReader = File.OpenText(filePath))
+                {
+                    template = await streamReader.ReadToEndAsync();
+                }
+
+                _memoryCache.Set(templateType, template);
             }
+
+            return template;
         }
 
         private string FormatTemplate(string template, EmailRequestModel emailRequest)

--- a/backend/src/StamAcasa.EmailService/Program.cs
+++ b/backend/src/StamAcasa.EmailService/Program.cs
@@ -1,4 +1,5 @@
 using EasyNetQ;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -62,6 +63,7 @@ namespace StamAcasa.EmailService
                     )
                 );
 
+                services.AddSingleton<IMemoryCache, MemoryCache>();
                 services.AddSingleton<ITemplateFileSelector, TemplateFileSelector>();
                 services.AddTransient<IEmailBuilderService, EmailBuilderService>();
                 services.AddSingleton<IQueueService, QueueService>();


### PR DESCRIPTION
### What does it fix?

Closes #156 

Add MemoryCache dependency and use it to store email templates based on the template type

### How has it been tested?

I manually tested the changes. I published messages on the queue to be consumed by the EmailService. I debuged the EmailService to check whether the template was read from file or if it was retreived from cache
