### PR TITLE
add 2 new clients which will be configured using env vars

### DIFF
--- a/backend/src/StamAcasa.IdentityServer/appsettings.json
+++ b/backend/src/StamAcasa.IdentityServer/appsettings.json
@@ -85,6 +85,46 @@
             ],
             "AllowAccessTokensViaBrowser": true,
             "AccessTokenType": 1
+        },
+        {
+            "ClientId": "awsjsclient",
+            "ClientName": "Aws JavaScript Client",
+            "AllowedGrantTypes": [ "implicit" ],
+            "RequirePkce": false,
+            "RequireClientSecret": false,
+            "RequireConsent": false,
+            "RedirectUris": [
+
+            ],
+            "PostLogoutRedirectUris": [],
+            "AllowedCorsOrigins": [],
+            "AllowedScopes": [
+                "openid",
+                "email",
+                "answersApi",
+                "usersApi"
+            ],
+            "AllowAccessTokensViaBrowser": true,
+            "AccessTokenType": 1
+        },
+        {
+            "ClientId": "swaggerClientAws",
+            "ClientName": "Aws Swagger UI Client",
+            "AllowedGrantTypes": [ "implicit" ],
+            "RequirePkce": false,
+            "RequireClientSecret": false,
+            "RequireConsent": false,
+            "RedirectUris": [],
+            "AllowedCorsOrigins": [],
+            "PostLogoutRedirectUris": [],
+            "AllowedScopes": [
+                "openid",
+                "email",
+                "answersApi",
+                "usersApi"
+            ],
+            "AllowAccessTokensViaBrowser": true,
+            "AccessTokenType": 1
         }
     ],
     "EnableEmailConfirmation": true,


### PR DESCRIPTION
closes #224 

to override aws clients use this env vars 
for Client (do not forget to set clientId in frontend to **awsjsclient**
```
ClientApplications__3__AllowedCorsOrigins__0: 'http://localhost:5002'
ClientApplications__3__PostLogoutRedirectUris__0: 'http://localhost:5002/post-logout'
ClientApplications__3__RedirectUris__0: 'http://localhost:5002/signin-oidc'
ClientApplications__3__RedirectUris__1: 'http://localhost:5002/silent-refresh'
```
for api (do not forget to se SwaggerOidcClientName to **swaggerClientAws**
```
ClientApplications__4__AllowedCorsOrigins__0: 'http://localhost:5008'
ClientApplications__4__RedirectUris__0: 'http://localhost:5008/swagger/oauth2-redirect.html'

```