### PR TITLE
#226 Add auth guard for Account component + fix duplicate sidebar

### DIFF
--- a/frontend/src/components/Account/Account.js
+++ b/frontend/src/components/Account/Account.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from "react";
+import { Hero } from "@code4ro/taskforce-fe-components";
+
+import "./Account.scss";
+
+import SidebarLayout from "../SidebarLayout";
+import Tabs from "../Tabs/Tabs";
+import BasePage from "../BasePage";
+import StepsBar from "../StepsBar";
+
+import MyAccount from "./MyAccount";
+import MemberAccount from "./MemberAccount";
+import CreateProfile from "./CreateProfile";
+
+import ProfileApi from "../../api/profileApi";
+
+export const Account = () => {
+  const [userProfile, setUserProfile] = useState(null);
+
+  const updateProfileFromServer = () => {
+    ProfileApi.get().then(setUserProfile);
+  };
+
+  useEffect(() => updateProfileFromServer(), []);
+
+  const tabs = [
+    {
+      id: 0,
+      title: "Profilul meu",
+      content: <MyAccount />,
+      url: "/account/me"
+    },
+    {
+      id: 1,
+      title: "Alte persoane",
+      content: <MemberAccount />,
+      url: "/account/other-members/:personId?",
+      navUrl: "/account/other-members"
+    }
+  ];
+
+  const getContent = () => {
+    const loading = userProfile === null;
+    if (loading) {
+      return <div>Datele se incarca</div>;
+    }
+
+    const profileEmpty = userProfile.id === undefined;
+    if (profileEmpty) {
+      return <CreateProfile onFinish={updateProfileFromServer} />;
+    }
+
+    return <Tabs tabs={tabs} />;
+  };
+
+  return (
+    <BasePage>
+      <Hero
+        title="Ce pași ai de urmat"
+        subtitle="Pentru a te putea ajuta iata ce ai la dispozitie in contul tau:"
+        useFallbackIcon={true}
+      />
+      <StepsBar
+        isProfileComplete={userProfile !== null && userProfile.id !== undefined}
+      />
+      <SidebarLayout>{getContent()}</SidebarLayout>
+    </BasePage>
+  );
+};
+
+export default Account;

--- a/frontend/src/components/Account/index.js
+++ b/frontend/src/components/Account/index.js
@@ -1,70 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
-import "./Account.scss";
+import Account from "./Account";
 
-import SidebarLayout from "../SidebarLayout";
+import { useSelector } from "react-redux";
+import { sel as userSel } from "../../store/ducks/user";
 
-import MyAccount from "./MyAccount";
-import MemberAccount from "./MemberAccount";
-import Tabs from "../Tabs/Tabs";
-import BasePage from "../BasePage";
-import { Hero } from "@code4ro/taskforce-fe-components";
-import StepsBar from "../StepsBar";
-import ProfileApi from "../../api/profileApi";
-import CreateProfile from "./CreateProfile";
+const AccountWithAuth = () => {
+  const isAuthenticated = useSelector(userSel.user);
 
-export const Account = () => {
-  const [userProfile, setUserProfile] = useState(null);
-
-  const updateProfileFromServer = () => {
-    ProfileApi.get().then(setUserProfile);
-  };
-
-  useEffect(updateProfileFromServer, []);
-
-  const tabs = [
-    {
-      id: 0,
-      title: "Profilul meu",
-      content: <MyAccount />,
-      url: "/account/me"
-    },
-    {
-      id: 1,
-      title: "Alte persoane",
-      content: <MemberAccount />,
-      url: "/account/other-members/:personId?",
-      navUrl: "/account/other-members"
-    }
-  ];
-
-  const getContent = () => {
-    const loading = userProfile === null;
-    if (loading) {
-      return <div>Datele se incarca</div>;
-    }
-
-    const profileEmpty = userProfile.id === undefined;
-    if (profileEmpty) {
-      return <CreateProfile onFinish={updateProfileFromServer} />;
-    }
-
-    return <Tabs tabs={tabs} />;
-  };
-
-  return (
-    <BasePage>
-      <Hero
-        title="Ce pași ai de urmat"
-        subtitle="Pentru a te putea ajuta iata ce ai la dispozitie in contul tau:"
-        useFallbackIcon={true}
-      />
-      <StepsBar
-        isProfileComplete={userProfile !== null && userProfile.id !== undefined}
-      />
-      <SidebarLayout>{getContent()}</SidebarLayout>
-    </BasePage>
-  );
+  return isAuthenticated ? <Account isAuthenticated={isAuthenticated} /> : null;
 };
 
-export default Account;
+export default AccountWithAuth;

--- a/frontend/src/components/Account/index.js
+++ b/frontend/src/components/Account/index.js
@@ -8,7 +8,7 @@ import { sel as userSel } from "../../store/ducks/user";
 const AccountWithAuth = () => {
   const isAuthenticated = useSelector(userSel.user);
 
-  return isAuthenticated ? <Account isAuthenticated={isAuthenticated} /> : null;
+  return isAuthenticated ? <Account /> : null;
 };
 
 export default AccountWithAuth;

--- a/frontend/src/components/AddMember/index.js
+++ b/frontend/src/components/AddMember/index.js
@@ -100,35 +100,33 @@ export const ProfileForm = ({ sendResults, forYourself }) => {
 
   const titlesForForm = forYourself ? titles.forYourself : titles.forOthers;
   return (
-    <SidebarLayout>
-      <form onSubmit={submitForm} className="user-profile-form">
-        {currentStep === 1 && (
-          <PersonalData
-            userData={userData}
-            setUserDataField={setUserDataField}
-            showRelationship={!forYourself}
-          />
-        )}
-        {currentStep === 2 && (
-          <Health
-            userData={userData}
-            setUserDataField={setUserDataField}
-            titles={titlesForForm.health}
-          />
-        )}
-        {currentStep === 3 && (
-          <Context
-            userData={userData}
-            setUserDataField={setUserDataField}
-            titles={titlesForForm.context}
-          />
-        )}
+    <form onSubmit={submitForm} className="user-profile-form">
+      {currentStep === 1 && (
+        <PersonalData
+          userData={userData}
+          setUserDataField={setUserDataField}
+          showRelationship={!forYourself}
+        />
+      )}
+      {currentStep === 2 && (
+        <Health
+          userData={userData}
+          setUserDataField={setUserDataField}
+          titles={titlesForForm.health}
+        />
+      )}
+      {currentStep === 3 && (
+        <Context
+          userData={userData}
+          setUserDataField={setUserDataField}
+          titles={titlesForForm.context}
+        />
+      )}
 
-        <Button type="warning" inputType="submit" disabled={!canGoNext()}>
-          Continuă
-        </Button>
-      </form>
-    </SidebarLayout>
+      <Button type="warning" inputType="submit" disabled={!canGoNext()}>
+        Continuă
+      </Button>
+    </form>
   );
 };
 
@@ -139,7 +137,11 @@ const AddMember = () => {
     ProfileApi.addDependant(userData).then(() => history.push("/account/me"));
   };
 
-  return <ProfileForm sendResults={sendResults} forYourself={false} />;
+  return (
+    <SidebarLayout>
+      <ProfileForm sendResults={sendResults} forYourself={false} />
+    </SidebarLayout>
+  );
 };
 
 ProfileForm.propTypes = {


### PR DESCRIPTION
### What does it fix?

The actual issue was that after logging in, when the user was redirected to the account page, there was a race condition where the GET profile request was fired before auth was settled, resulting in a 401 response from the server.
In order to fix this issue, there is a check performed before rendering the account page, thus not calling GET profile until everything is settled.
While auth is being settled after login, the user will stare at a blank page (`null` is returned from render until auth is finished). Alternatively, if this behaviour is unwanted, the Account component could be refactored and the loading message could be displayed until everything is settled.

Closes #226 

- `Account.js` is not a new file, `index.js` was renamed;
- `AccountWithAuth` is first checking that there is a user authenticated before rendering `Account`;

- Moved `SidebarLayout` outside the reusable form;

- Known issue: after logout, users will see a blank page until #227 is fixed.

### How has it been tested?

Manual dev test with no profile & with profile;