### PR TITLE
#230 change call to publish email request

### DIFF
--- a/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
+++ b/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
@@ -24,7 +24,7 @@ namespace StamAcasa.Common.Notifications
         {
             var userInfos = await UserService.GetAll();
             var notifications = userInfos.Select(CreateEmailRequest);
-            var qTasks = notifications.Select(n => _queueService.PublishNotification(n));
+            var qTasks = notifications.Select(n => _queueService.PublishEmailRequest(n));
             await Task.WhenAll(qTasks);
         }
 


### PR DESCRIPTION
### What does it fix?

Closes #230 

I changed the method call in AssessmentNotificationsDispatch, to PublishEmailRequest

### How has it been tested?

I manually tested the change
* changed the job scheduler frequency (locally) to run every minute
* checked the rabbit queue to see the expected message queues being published
* started the email service and checked the email service logs
