### PR TITLE
Bug/redirect home after email confirmation

### DIFF
--- a/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
+++ b/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
@@ -24,7 +24,7 @@ namespace StamAcasa.Common.Notifications
         {
             var userInfos = await UserService.GetAll();
             var notifications = userInfos.Select(CreateEmailRequest);
-            var qTasks = notifications.Select(n => _queueService.PublishNotification(n));
+            var qTasks = notifications.Select(n => _queueService.PublishEmailRequest(n));
             await Task.WhenAll(qTasks);
         }
 

--- a/backend/src/StamAcasa.IdentityServer/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/backend/src/StamAcasa.IdentityServer/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -47,6 +47,7 @@ namespace IdentityServer.Pages.Account
         [BindProperty]
         public InputModel Input { get; set; }
 
+        [FromQuery]
         public string ReturnUrl { get; set; }
 
         public IList<AuthenticationScheme> ExternalLogins { get; set; }
@@ -92,7 +93,7 @@ namespace IdentityServer.Pages.Account
             await _queue.PublishEmailRequest<EmailRequestModel>(email);
         }
 
-        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        public async Task<IActionResult> OnPostAsync([FromQuery] string returnUrl = null)
         {
             returnUrl ??= Url.Content("~/");
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();


### PR DESCRIPTION
### What does it fix?

Closes #234

include the return url from the register call into the email confirmation message

### How has it been tested?

I checked that the message published in the queue contains the correct return url:
 * message
{"Address":"c.c@c.com","Type":"accountConfirmationTemplate","PlaceholderContent":{"name":"c.c@c.com","confirmationLink":"http://localhost:5001/Identity/Account/ConfirmEmail?userId=0eb020d2-c90f-4a8f-aa73-7a7d73ef045d&amp;code ... ;**returnUrl=http%3A%2F%2Flocalhost%3A5002%2Fregister-complete**"},"TemplateType":0,"Attachment":null,"Subject":"","SenderName":"Admin Stam Acasa"}