### PR TITLE
#235 Fix url redirects

### DIFF
--- a/frontend/src/components/Evaluation/finishFormButton.js
+++ b/frontend/src/components/Evaluation/finishFormButton.js
@@ -1,13 +1,19 @@
 import React from "react";
 import { Button } from "@code4ro/taskforce-fe-components";
-import "./evalutation.scss";
 import { useHistory } from "react-router-dom";
+
+import "./evalutation.scss";
 
 const FinishFormButton = () => {
   const history = useHistory();
+
   return (
     <div className={"call-to-action"}>
-      <Button onClick={() => history.push("/")} size={"large"} inverted={true}>
+      <Button
+        onClick={() => history.push("/account")}
+        size={"large"}
+        inverted={true}
+      >
         Intoarce-te la pagina principala
       </Button>
     </div>

--- a/frontend/src/components/Header/ProfileItems.js
+++ b/frontend/src/components/Header/ProfileItems.js
@@ -14,7 +14,7 @@ const ProfileItems = () => {
     <span className="account-items">
       {user ? (
         <>
-          <NavLink to="/">Contul meu</NavLink>
+          <NavLink to="/account">Contul meu</NavLink>
           <div className="account-separator" />
           <button onClick={handleLogout}>Logout</button>
         </>

--- a/frontend/src/components/Home/components/UserHomePage.js
+++ b/frontend/src/components/Home/components/UserHomePage.js
@@ -47,7 +47,7 @@ const UserHomePage = ({ isAuthenticated }) => {
 };
 
 UserHomePage.propTypes = {
-  isAuthenticated: PropTypes.bool,
-}
+  isAuthenticated: PropTypes.bool
+};
 
 export default UserHomePage;

--- a/frontend/src/components/Home/components/UserHomePage.js
+++ b/frontend/src/components/Home/components/UserHomePage.js
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from "react";
-
+import PropTypes from "prop-types";
 import { Hero } from "@code4ro/taskforce-fe-components";
+
 import StepsBar from "../../StepsBar";
-import { ROUTES } from "../../../routes";
-import ProfileApi from "../../../api/profileApi";
 import AuthenticatedRoute from "../../AuthenticatedRoute";
 
-const UserHomePage = () => {
+import { ROUTES } from "../../../routes";
+import ProfileApi from "../../../api/profileApi";
+import useAuthHomeRedirect from "../../../hooks/redirect";
+
+const UserHomePage = ({ isAuthenticated }) => {
+  useAuthHomeRedirect(isAuthenticated);
   const [userProfile, setUserProfile] = useState(null);
 
   const updateProfileFromServer = () => {
@@ -41,5 +45,9 @@ const UserHomePage = () => {
     </>
   );
 };
+
+UserHomePage.propTypes = {
+  isAuthenticated: PropTypes.bool,
+}
 
 export default UserHomePage;

--- a/frontend/src/components/Home/index.js
+++ b/frontend/src/components/Home/index.js
@@ -7,7 +7,12 @@ import { sel as userSel } from "../../store/ducks/user";
 
 const Home = () => {
   const isAuthenticated = useSelector(userSel.user);
-  const page = isAuthenticated ? <UserHomePage /> : <DefaultHomePage />;
+  const page = isAuthenticated ? (
+    <UserHomePage isAuthenticated />
+  ) : (
+    <DefaultHomePage />
+  );
+
   return <BasePage>{page}</BasePage>;
 };
 

--- a/frontend/src/hooks/redirect.js
+++ b/frontend/src/hooks/redirect.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { useLocation, useHistory } from "react-router-dom";
+
+const HOME_PATH = {
+  DEFAULT: "/",
+  REDIRECT: "/account"
+};
+
+const useAuthHomeRedirect = isAuthenticated => {
+  const location = useLocation();
+  const history = useHistory();
+
+  React.useEffect(() => {
+    if (isAuthenticated && location.pathname === HOME_PATH.DEFAULT) {
+      history.replace(HOME_PATH.REDIRECT);
+    }
+  }, [location]);
+};
+
+export default useAuthHomeRedirect;


### PR DESCRIPTION
### What does it fix?

Closes #235 #236 #238 

- Evaluation form finish button redirects to `/account`
- 'Contul meu' nav item redirects to `/account`

Added a custom hook that redirects authenticated users to `/account` when navigating to default home route -`/` (e.g: clicking the logo, accessing the app while logged in via browser address manual input).

### How has it been tested?

Manual dev test.
