### PR TITLE
send email notifications only to parents

### DIFF
--- a/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
+++ b/backend/src/StamAcasa.Common/Notifications/AssessmentNotificationsDispatch.cs
@@ -22,7 +22,7 @@ namespace StamAcasa.Common.Notifications
 
         public async Task Process()
         {
-            var userInfos = await UserService.GetAll();
+            var userInfos = await UserService.GetAllParents();
             var notifications = userInfos.Select(CreateEmailRequest);
             var qTasks = notifications.Select(n => _queueService.PublishEmailRequest(n));
             await Task.WhenAll(qTasks);

--- a/backend/src/StamAcasa.Common/Services/IUserService.cs
+++ b/backend/src/StamAcasa.Common/Services/IUserService.cs
@@ -13,5 +13,6 @@ namespace StamAcasa.Common.Services {
         Task<UserInfo> GetUserInfo(int id);
         Task<IEnumerable<UserInfo>> GetDependentInfo(string sub);
         Task<IEnumerable<UserInfo>> GetAll();
+        Task<IEnumerable<UserInfo>> GetAllParents();
     }
 }

--- a/backend/src/StamAcasa.Common/Services/UserService.cs
+++ b/backend/src/StamAcasa.Common/Services/UserService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -92,6 +93,19 @@ namespace StamAcasa.Common.Services
         {
             var users = await _context.Users.ToListAsync();
             var result = users.Select(_mapper.Map<UserInfo>);
+            return result;
+        }
+
+        public async Task<IEnumerable<UserInfo>> GetAllParents()
+        {
+            var parents = new ConcurrentQueue<User>();
+            await _context.Users.ForEachAsync(u =>
+            {
+                if (!u.ParentId.HasValue)
+                    parents.Enqueue(u);
+            });
+
+            var result = parents.Select(_mapper.Map<UserInfo>);
             return result;
         }
     }


### PR DESCRIPTION
### What does it fix?

As indicated by issue #246, the change was made in the `AssessmentNotificationsDispatch:Process` calling a new function that only returns root parents (the ones that don't have a `ParentId`).

N.B. This is a new iteration of the initial PR #289 rebased on latest `upstream/develop`.

### How has it been tested?

In the console, I checked the logs. Previously there were emails being sent to all users and after the change only to Alice who was a "root parent".
