### PR TITLE
#276 Comment out dashboard route

### DIFF
--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,18 +11,17 @@ import {
   silentRefreshCallback
 } from "./api/auth";
 
-import BaseDashboard from "./components/BaseDashboard";
-
 export const ROUTES = {
   base: {
     despre: {
       path: "/despre",
       component: About
     },
-    dashboard: {
-      path: "/dashboard",
-      component: BaseDashboard
-    },
+    // TODO Uncomment when dashboard is needed again
+    // dashboard: {
+    //   path: "/dashboard",
+    //   component: BaseDashboard
+    // },
     home: {
       path: "/",
       component: Home


### PR DESCRIPTION
### What does it fix?

Closes #276 

Just commented the dashboard route config.

Note: `/dashboard` is now an unknown route. Unknown routes (or 404s) are not handled, so the user is presented with the three inactive tabs and the url does not change.

### How has it been tested?
Manual dev test.
