### PR TITLE
Fix update for own profile

### DIFF
--- a/frontend/src/components/AddMember/index.js
+++ b/frontend/src/components/AddMember/index.js
@@ -158,7 +158,15 @@ export const ProfileForm = ({
         userData.livesWithOthers = false;
       }
 
-      sendResults(userData);
+      const preexistingMedicalCondition = mapPreExistMedCondTexts(
+        userData.preexistingMedicalCondition
+      );
+      const formattedUserData = {
+        ...userData,
+        preexistingMedicalCondition
+      };
+
+      sendResults(formattedUserData);
     }
   };
 
@@ -208,14 +216,7 @@ const AddMember = () => {
   const history = useHistory();
 
   const sendResults = userData => {
-    const preexistingMedicalCondition = mapPreExistMedCondTexts(
-      userData.preexistingMedicalCondition
-    );
-    const formattedUserData = {
-      ...userData,
-      preexistingMedicalCondition
-    };
-    ProfileApi.addDependant(formattedUserData).then(({ data: id }) =>
+    ProfileApi.addDependant(userData).then(({ data: id }) =>
       history.push(`/account/other-members/${id}`)
     );
   };

--- a/frontend/src/components/UpdateProfile/index.js
+++ b/frontend/src/components/UpdateProfile/index.js
@@ -13,18 +13,19 @@ const UpdateProfile = ({
 }) => {
   const history = useHistory();
   const sendResults = userData => {
+    const preexistingMedicalCondition = mapPreExistMedCondTexts(
+      userData.preexistingMedicalCondition
+    );
+    const formattedUserData = {
+      ...userData,
+      preexistingMedicalCondition
+    };
+
     if (isSelf) {
-      ProfileApi.updateProfile(id, userData).then(() =>
+      ProfileApi.updateProfile(id, formattedUserData).then(() =>
         history.push("/account/me")
       );
     } else {
-      const preexistingMedicalCondition = mapPreExistMedCondTexts(
-        userData.preexistingMedicalCondition
-      );
-      const formattedUserData = {
-        ...userData,
-        preexistingMedicalCondition
-      };
       ProfileApi.updateFamilyProfile(id, formattedUserData).then(() =>
         history.push(`/account/other-members/${id}`)
       );

--- a/frontend/src/components/UpdateProfile/index.js
+++ b/frontend/src/components/UpdateProfile/index.js
@@ -4,7 +4,6 @@ import ProfileApi from "../../api/profileApi";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
 import SidebarLayout from "../SidebarLayout";
-import { mapPreExistMedCondTexts } from "../../utils";
 
 const UpdateProfile = ({
   location: {
@@ -13,20 +12,12 @@ const UpdateProfile = ({
 }) => {
   const history = useHistory();
   const sendResults = userData => {
-    const preexistingMedicalCondition = mapPreExistMedCondTexts(
-      userData.preexistingMedicalCondition
-    );
-    const formattedUserData = {
-      ...userData,
-      preexistingMedicalCondition
-    };
-
     if (isSelf) {
-      ProfileApi.updateProfile(id, formattedUserData).then(() =>
+      ProfileApi.updateProfile(id, userData).then(() =>
         history.push("/account/me")
       );
     } else {
-      ProfileApi.updateFamilyProfile(id, formattedUserData).then(() =>
+      ProfileApi.updateFamilyProfile(id, userData).then(() =>
         history.push(`/account/other-members/${id}`)
       );
     }


### PR DESCRIPTION
### Issue
When creating or updating your own profile, the representation of the `preexistingMedicalCondition` is using values (eg. 1) instead of text descriptions (eg. diabet). This means that when looking at the profile details we see those values rather than text description.

### Fix
Apply the mapping from values to text description for all uses of ProfileForm. Currently, the cases for creating/updating your own profile the mapping doesnt happen
