### PR TITLE
Fix postgres directory permission error on Windows 10 & new docker-compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ docker-compose -f docker-compose-services.yml -f docker-compose.override.yml up
 ```
 Is also starting the frontend on port `5002`
 
+Alternatively 2: Start only the backend
+(frontend has to be started using the instructions below)
+
+```
+cd backend/src
+docker-compose -f docker-compose-backend-only.yml up
+```
+
 ### Frontend
 1. Install dependencies
 

--- a/backend/src/docker-compose-backend-only.yml
+++ b/backend/src/docker-compose-backend-only.yml
@@ -1,0 +1,92 @@
+version: '3.4'
+
+services:
+  postgres:
+    image: postgres
+    container_name: postgres
+    environment:
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_USER=docker
+      - POSTGRES_DB=postgres
+      - PGDATA=/tmp
+    ports:
+      - 5432:5432
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+
+  rabbitmq:
+    image: local_rabbit
+    restart: always
+    container_name: rabbitmq
+    build:
+      context: rabbitconfig/
+      dockerfile: Dockerfile
+    ports:
+      # The standard AMQP protocol port
+      - 5672:5672
+      # HTTP management UI
+      - 15672:15672
+
+  stamacasa.api:
+    image: ${DOCKER_REGISTRY-}stamacasa-api
+    build:
+      context: .
+      dockerfile: StamAcasa.Api/Dockerfile
+    environment:
+      - ASPNETCORE_URLS=http://+:80
+      - IdentityServerUrl=http://identityserver
+      - ASPNETCORE_ENVIRONMENT=Development
+    ports:
+      - 5008:80
+    depends_on:
+      - identityserver
+      - postgres
+      # volumes:
+      #- ${HOME}/.microsoft/usersecrets/:/root/.microsoft/usersecrets
+      #- ${HOME}/.aspnet/https:/root/.aspnet/https/
+
+  identityserver:
+    image: ${DOCKER_REGISTRY-}stamacasa-identityserver
+    environment:
+      ASPNETCORE_URLS: 'http://+:80'
+      RABBITMQ__USER: admin
+      RABBITMQ__PASSWORD: Corona2020
+      RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__PORT: 5672
+      ASPNETCORE_ENVIRONMENT: Development
+    build:
+      context: .
+      dockerfile: StamAcasa.IdentityServer/Dockerfile
+    ports:
+      - 5001:80
+    container_name: identityserver
+    hostname: identityserver
+    depends_on:
+      - postgres
+
+  stamacasa.email:
+    image: ${DOCKER_REGISTRY-}stamacasa-email
+    build:
+      context: .
+      dockerfile: StamAcasa.EmailService/Dockerfile
+    environment:
+      RABBITMQ__USER: admin
+      RABBITMQ__PASSWORD: Corona2020
+      RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__PORT: 5672
+      SMTP__HOST: smtp.domain.com
+      SMTP__PORT: 587
+      SMTP__USER: email@domain.com
+      SMTP__PASSWORD: password
+      DOTNET_ENVIRONMENT: Development
+
+  stamacasa.jobscheduler:
+    image: ${DOCKER_REGISTRY-}stamacasa-jobscheduler
+    build:
+      context: .
+      dockerfile: StamAcasa.JobScheduler/Dockerfile
+    environment:
+      RABBITMQ__USER: admin
+      RABBITMQ__PASSWORD: Corona2020
+      RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__PORT: 5672

--- a/backend/src/docker-compose-dep.yml
+++ b/backend/src/docker-compose-dep.yml
@@ -8,6 +8,7 @@ services:
       - POSTGRES_PASSWORD=docker
       - POSTGRES_USER=docker
       - POSTGRES_DB=postgres
+      - PGDATA=/tmp
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
### What does it fix?

1. On Windows 10, docker containers won't start because of a postgress directory permission error.
After some research, I found a solution that works on this [forum](https://forums.docker.com/t/data-directory-var-lib-postgresql-data-pgdata-has-wrong-ownership/17963/20)

1. Combine the docker-compose files into a single file that starts all services except the frontend

1. Updated the README.md with the new command

### How has it been tested?
Locally the project now starts after running
```
# Start project - the old command
docker-compose -f docker-compose-dep.yml up
docker-compose -f docker-compose-services.yml -f docker-compose.override.yml up

# Start project - new command
# Start backend
docker-compose -f docker-compose-backend-only.yml

# Start frontend
npm run start
```

#### Windows 10 error
![image](https://user-images.githubusercontent.com/7374942/80209246-5fb2cd00-863a-11ea-95c5-3ec6f1ef0ed5.png)

#### Docker version
![image](https://user-images.githubusercontent.com/7374942/80209121-22e6d600-863a-11ea-8bd9-0b922111b01d.png)

