### PR TITLE
Removed useless whitespace on 'Profilul meu' and 'Alte persoane' pages

### DIFF
--- a/frontend/src/components/Account/MyAccount/MyAccount.scss
+++ b/frontend/src/components/Account/MyAccount/MyAccount.scss
@@ -1,5 +1,5 @@
 .account-container {
-    margin-bottom: 200px;
+    margin-bottom: 0px;
     .account-header {
         font-weight: bold;
         font-size: 20px;

--- a/frontend/src/components/Account/common/ProfileHistory/ProfileHistory.scss
+++ b/frontend/src/components/Account/common/ProfileHistory/ProfileHistory.scss
@@ -1,7 +1,7 @@
 .profile-history-container {
-    margin-bottom: 200px;
+    margin-bottom: 0px;
     .profile-history-text {
-        margin: 44px 0;
+        margin: 44px 0px 0px 0px;
         font-size: 14px;
     }
     .link{


### PR DESCRIPTION
### What does it fix?

https://github.com/code4romania/stam-acasa/issues/304#event-3259034609

This PR changes the CSS margins that are used on profile-history-container and account-container so that the whitespace on mobile mode is reduced.
| Before  | After |
| ------------- | ------------- |
| <img width="200" alt="Screenshot 2020-04-24 at 15 18 31" src="https://user-images.githubusercontent.com/44275480/80212986-29c51700-8641-11ea-8b31-1b8b402e37dd.png"> | <img width="200" alt="Screenshot 2020-04-24 at 15 18 57" src="https://user-images.githubusercontent.com/44275480/80213004-2fbaf800-8641-11ea-991a-07455da9456d.png">  |





### How has it been tested?
I tested the page on different window sizes and the content aligns properly on all of them.
Browsers used for testing: Brave and Safari for macOS
