### PR TITLE
Hide persons in care from their profile

### DIFF
--- a/frontend/src/components/Account/common/ProfileDetails/ProfileDetails.js
+++ b/frontend/src/components/Account/common/ProfileDetails/ProfileDetails.js
@@ -43,10 +43,12 @@ const ProfileDetails = ({
           </div>
         ))}
       </div>
-      <div className="footer">
-        <hr />
-        {children}
-      </div>
+      {isSelf && (
+        <div className="footer">
+          <hr />
+          {children}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### What does it fix?

Closes #301 

Hides `Alte persoane în grijă:` from their profile details.