### PR TITLE
add strict https redirection

### DIFF
--- a/backend/src/StamAcasa.Api/Startup.cs
+++ b/backend/src/StamAcasa.Api/Startup.cs
@@ -41,6 +41,13 @@ namespace StamAcasa.Api
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddHsts(options =>
+            {
+                options.Preload = true;
+                options.IncludeSubDomains = true;
+                options.MaxAge = TimeSpan.FromDays(365);
+            });
+
             services.AddControllers();
             var identityUrl = Configuration.GetValue<string>("InternalIdentityServerUrl");
             var apiSchemes = new List<ApiAuthenticationScheme>();
@@ -98,6 +105,12 @@ namespace StamAcasa.Api
 
         public void Configure(IApplicationBuilder app, UserDbContext dbContext)
         {
+            if (!_environment.IsDevelopment())
+            {
+                app.UseHsts();
+                app.UseHttpsRedirection();
+            }
+
             dbContext.Database.Migrate();
 
             app.UseRouting();

--- a/backend/src/StamAcasa.Api/appsettings.json
+++ b/backend/src/StamAcasa.Api/appsettings.json
@@ -1,29 +1,30 @@
 ﻿{
-  "ConnectionStrings": {
-    "UserDBConnection": "Server=postgres;Port=5432;Database=UserDb;User Id=docker;Password=docker;"
-  },
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  },
-  "IdentityServerUrl": "http://localhost:5001",
-  "InternalIdentityServerUrl": "http://identityserver",
-  "AllowedCorsOrigins": [ "http://localhost:3000", "http://localhost:5002" ],
-  "ApiConfiguration": [
-    {
-      "ApiName": "answersApi",
-      "ApiSecret": "svpqYnJSR8xzn8Rl"
+    "https_port": 443,
+    "ConnectionStrings": {
+        "UserDBConnection": "Server=postgres;Port=5432;Database=UserDb;User Id=docker;Password=docker;"
     },
-    {
-      "ApiName": "usersApi",
-      "ApiSecret": "st4k!b7s$af201cv"
-    }
-  ],
-  "TargetFolder": "answers",
-  "StorageType": "FileSystem",
-  "SwaggerOidcClientName": "swaggerClientLocalhost"
+    "Logging": {
+        "IncludeScopes": false,
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    },
+    "IdentityServerUrl": "http://localhost:5001",
+    "InternalIdentityServerUrl": "http://identityserver",
+    "AllowedCorsOrigins": [ "http://localhost:3000", "http://localhost:5002" ],
+    "ApiConfiguration": [
+        {
+            "ApiName": "answersApi",
+            "ApiSecret": "svpqYnJSR8xzn8Rl"
+        },
+        {
+            "ApiName": "usersApi",
+            "ApiSecret": "st4k!b7s$af201cv"
+        }
+    ],
+    "TargetFolder": "answers",
+    "StorageType": "FileSystem",
+    "SwaggerOidcClientName": "swaggerClientLocalhost"
 }

--- a/backend/src/StamAcasa.IdentityServer/Startup.cs
+++ b/backend/src/StamAcasa.IdentityServer/Startup.cs
@@ -27,8 +27,13 @@ namespace IdentityServer
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-
             services.AddRazorPages();
+            services.AddHsts(options =>
+            {
+                options.Preload = true;
+                options.IncludeSubDomains = true;
+                options.MaxAge = TimeSpan.FromDays(365);
+            });
             services.AddControllersWithViews();
             var builder = services.AddIdentityServer(options =>
                 {

--- a/backend/src/StamAcasa.IdentityServer/appsettings.json
+++ b/backend/src/StamAcasa.IdentityServer/appsettings.json
@@ -1,4 +1,5 @@
 {
+    "https_port": 443,
     "Logging": {
         "LogLevel": {
             "Default": "Information",
@@ -126,7 +127,7 @@
             "AllowAccessTokensViaBrowser": true,
             "AccessTokenType": 1
         }
-    ],    
+    ],
     "EMailingSystem": "SendGrid",
     "AdminFromName": "Admin",
     "AdminFromEmail": "admin@stam-acasa.ro",


### PR DESCRIPTION
based on info found [here ](https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-3.1&tabs=visual-studio)
closes #439

**Important!**
If our apps (api, frontend, identityserver) are deployed using a reverse proxy then reverse proxy should handle https redirection and headers in response