### PR TITLE
Enable Secure cookies

### DIFF
--- a/backend/src/StamAcasa.Api/Startup.cs
+++ b/backend/src/StamAcasa.Api/Startup.cs
@@ -114,6 +114,12 @@ namespace StamAcasa.Api
             dbContext.Database.Migrate();
 
             app.UseRouting();
+            var cookiePolicyOptions = new CookiePolicyOptions
+            {
+                // Mark cookies as `Secure` (only if using HTTPS in development, and always in production)
+                Secure = _environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always
+            };
+            app.UseCookiePolicy(cookiePolicyOptions);
             app.Use(CustomMiddleware);
             app.UseCors("default");
 

--- a/backend/src/StamAcasa.IdentityServer/Startup.cs
+++ b/backend/src/StamAcasa.IdentityServer/Startup.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using IdentityServer.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,7 +13,6 @@ using StamAcasa.Common.Services.Emailing;
 using StamAcasa.IdentityServer;
 using StamAcasa.Common.Queue;
 using EasyNetQ;
-using Microsoft.AspNetCore.Mvc.Routing;
 using StamAcasa.IdentityServer.Helpers;
 using StamAcasa.IdentityServer.Options;
 
@@ -150,6 +150,13 @@ namespace IdentityServer
 
             app.UseRouting();
             app.UseStaticFiles();
+            var cookiePolicyOptions = new CookiePolicyOptions
+            {
+                // Mark cookies as `Secure` (only if using HTTPS in development, and always in production)
+                Secure = env.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always
+            };
+            app.UseCookiePolicy(cookiePolicyOptions);
+
             app.UseIdentityServer();
             app.UseAuthentication();
             app.UseAuthorization();


### PR DESCRIPTION
### What does it fix?

Closes #434

Marks cookies with the `Secure` flag. Uses the ASP.NET Core [Cookie Policy Middleware](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie?view=aspnetcore-3.1#cookie-policy-middleware).

### How has it been tested?

I've ran it locally and it didn't cause issues on `http://localhost`.

I'm not entirely sure how to test it enables `Secure` cookies on HTTPS connections without deploying it to staging :thinking: