### PR TITLE
Only show install extension item in sidebar if user has matching browser

### DIFF
--- a/frontend/src/components/SidebarLayout/const.js
+++ b/frontend/src/components/SidebarLayout/const.js
@@ -1,18 +1,21 @@
-export const instrumentsItems = [
-  {
+export const browserExtensions = {
+  chrome: {
     color: "green",
     title: "Instalează-ți extensia de Chrome pentru a depista știri false",
     ctaText: "Instalează extensia",
     ctaLink:
       "https://chrome.google.com/webstore/detail/covid-19-stiri-oficiale/pdcpkplohipjhdfdchpmgekifmcdbnha"
   },
-  {
+  firefox: {
     color: "green",
     title: "Instalează-ți extensia de Firefox pentru a depista știri false",
     ctaText: "Instalează extensia",
     ctaLink:
       "https://addons.mozilla.org/en-US/firefox/addon/covid-19-%C8%99tiri-oficiale/"
-  },
+  }
+};
+
+export const instrumentsItems = [
   {
     color: "green",
     title: "Știri oficiale și informații la zi",

--- a/frontend/src/components/SidebarLayout/index.js
+++ b/frontend/src/components/SidebarLayout/index.js
@@ -5,24 +5,31 @@ import {
   InstrumentsItem,
   Hero
 } from "@code4ro/taskforce-fe-components";
-import { instrumentsItems } from "./const";
+import { browserExtensions, instrumentsItems } from "./const";
 
 const SidebarLayout = ({ children }) => {
+  // Browser detection based on this answer:
+  // https://stackoverflow.com/a/9851769/5723188
+  const isChrome =
+    !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
+  const isFirefox = typeof InstallTrigger !== "undefined";
+
+  let installExtensionItem = null;
+  if (isChrome) {
+    installExtensionItem = <InstrumentsItem {...browserExtensions.chrome} />;
+  } else if (isFirefox) {
+    installExtensionItem = <InstrumentsItem {...browserExtensions.firefox} />;
+  }
+
   return (
     <div className="columns">
       <div className="column is-8">{children}</div>
       <aside className="column is-4">
         <Instruments layout="column">
           <Hero useFallbackIcon title="Instrumente utile" />
+          {installExtensionItem}
           {instrumentsItems.map((item, index) => (
-            <InstrumentsItem
-              key={index}
-              color={item.color}
-              title={item.title}
-              content={item.content}
-              ctaText={item.ctaText}
-              ctaLink={item.ctaLink}
-            />
+            <InstrumentsItem key={index} {...item} />
           ))}
         </Instruments>
       </aside>


### PR DESCRIPTION
### What does it fix?

Partially addresses #367 (in order to also display an icon as suggested, we'd need to first modify [InstrumentsItem](https://github.com/code4romania/taskforce-fe-components/blob/master/src/components/instruments-item/instruments-item.js))

The install extension item is only shown for the current browser.

### How has it been tested?

Locally tested it with Chromium and Firefox.