### PR TITLE
Fixed issues around checkbox for capturing that the user is allowed to capture data

### DIFF
--- a/frontend/src/components/AddMember/index.js
+++ b/frontend/src/components/AddMember/index.js
@@ -20,6 +20,7 @@ export const ProfileForm = ({
   const [currentStep, setCurrentStep] = useState(1);
   const [userData, setUserData] = useState(currentUserData);
 
+  const ALLOWED_TO_CAPTURE_DATA = "agree";
   const fieldsForYourself = [
     {
       name: "name",
@@ -48,7 +49,8 @@ export const ProfileForm = ({
     {
       name: "city",
       required: true
-    }
+    },
+    { name: ALLOWED_TO_CAPTURE_DATA, required: true }
   ];
   const fieldsForDependant = [
     {
@@ -83,7 +85,7 @@ export const ProfileForm = ({
       name: "relationshipType",
       required: false
     },
-    { name: "agree", required: true }
+    { name: ALLOWED_TO_CAPTURE_DATA, required: true }
   ];
   const personalFields = forYourself ? fieldsForYourself : fieldsForDependant;
 
@@ -117,11 +119,15 @@ export const ProfileForm = ({
     fields.filter(
       field =>
         field.required &&
-        (userData[field.name] === undefined || userData[field.name] == "")
+        (userData[field.name] === undefined || userData[field.name] === "")
     ).length === 0;
 
   const canGoNext = () => {
-    if (currentStep === 1 && fieldsCompleted(personalFields)) {
+    if (
+      currentStep === 1 &&
+      fieldsCompleted(personalFields) &&
+      userData[ALLOWED_TO_CAPTURE_DATA]
+    ) {
       return true;
     }
 


### PR DESCRIPTION
Fixes a couple of small issues:
- `false` value in an answer marks a question as unanswered. **Fix**: use "===" instead of "=="
- make the checkbox required when creating own profile
- add a separate check to make sure the value is true. The `fieldsCompleted` check only verifies is there is a value for the checkbox - not if that value is true